### PR TITLE
Improvements to PR #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An HTML to Markdown converter written in JavaScript.
 
 The API is as follows:
 
-    toMarkdown(stringOfHTML);
+    toMarkdown(stringOfHTML, options);
 
 ## Installation
 
@@ -32,6 +32,54 @@ Or with **Bower**:
     toMarkdown('<h1>Hello world!</h1>');
 
 (Note it is no longer necessary to call `.toMarkdown` on the required module as of v1.)
+
+## Options
+
+### `converters` (array)
+
+to-markdown can be extended by passing in an array of converters to the options object. A converter object consists of a **filter**, and a **replacement**. This example from the source replaces `code` elements:
+
+    {
+      filter: 'code',
+      replacement: function(innerHTML) {
+        return '`' + innerHTML + '`';
+      }
+    }
+
+#### `filter` (string|array|function)
+
+The filter property determines whether or not an element should be replaced. DOM nodes can be selected simply by filtering by tag name, with strings or with arrays of strings:
+
+* `filter: 'p'` will select `p` elements
+* `filter: ['em', 'i']` will select `em` or `i` elements
+
+Alternatively, the filter can be a function that returns a boolean depending on whether a given node should be replaced. The function is passed a DOM node as its only argument. For example, the following will match any `span` element with an `italic` style:
+
+    filter: function (node) {
+      return node.tagName.toLowerCase() === 'span' &&
+        /italic/i.test(node.style);
+    }
+
+#### `replacement` (function)
+
+The replacement function determines how an element should be converted. It should return the markdown string for a given node. The function is passed the node’s innerHTML[1], as well as the node itself (used in more complex conversions).
+
+The following converter replaces heading elements (`h1`-`h6`):
+
+    {
+      filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+
+      replacement: function(innerHTML, node) {
+        var hLevel = node.tagName.charAt(1);
+        var hPrefix = '';
+        for(var i = 0; i < hLevel; i++) {
+          hPrefix += '#';
+        }
+        return '\n' + hPrefix + ' ' + innerHTML + '\n\n';
+      }
+    }
+
+[1] The innerHTML parameter has had leading/trailing whitespace removed, and has HTML entities decoded.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ Or with **Bower**:
 
 ### `converters` (array)
 
-to-markdown can be extended by passing in an array of converters to the options object. A converter object consists of a **filter**, and a **replacement**. This example from the source replaces `code` elements:
+to-markdown can be extended by passing in an array of converters to the options object:
+
+    toMarkdown(stringOfHTML, { converters: [converter1, converter2, …] });
+
+A converter object consists of a **filter**, and a **replacement**. This example from the source replaces `code` elements:
 
     {
       filter: 'code',
@@ -53,11 +57,10 @@ The filter property determines whether or not an element should be replaced. DOM
 * `filter: 'p'` will select `p` elements
 * `filter: ['em', 'i']` will select `em` or `i` elements
 
-Alternatively, the filter can be a function that returns a boolean depending on whether a given node should be replaced. The function is passed a DOM node as its only argument. For example, the following will match any `span` element with an `italic` style:
+Alternatively, the filter can be a function that returns a boolean depending on whether a given node should be replaced. The function is passed a DOM node as its only argument. For example, the following will match any `span` element with an `italic` font style:
 
     filter: function (node) {
-      return node.tagName.toLowerCase() === 'span' &&
-        /italic/i.test(node.style);
+      return node.tagName === 'SPAN' && /italic/i.test(node.style.fontStyle);
     }
 
 #### `replacement` (function)

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ var he = require('he');
 
 var htmlToDom = require('./lib/html-to-dom');
 var converters = require('./lib/md-converters');
-var isArray = require('./lib/utilities').isArray;
 
 var VOID_ELEMENTS = [
   'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input',
@@ -72,7 +71,7 @@ function bfsOrder(root) {
 }
 
 function canConvertNode(node, filter) {
-  if (isArray(filter)) {
+  if (Array.isArray(filter)) {
     return filter.indexOf(node.tagName.toLowerCase()) !== -1;
   }
   else if (typeof filter === 'string') {

--- a/index.js
+++ b/index.js
@@ -18,17 +18,18 @@ var VOID_ELEMENTS = [
   'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'
 ];
 
-module.exports = function (input, opts) {
+module.exports = function (input, options) {
   if (typeof input !== 'string') {
     throw 'first argument needs to be an HTML string';
   }
+  options = options || {};
+
   // Escape potential ol triggers
   input = input.replace(/(\d+)\. /g, '$1\\. ');
-  opts = opts || {};
-  var customConverters = opts.converters || [];
-  // custom converters come first, because the replacement is executed on
+
+  // Custom converters come first, because the replacement is executed on
   // a first come first serve basis
-  converters = customConverters.concat(converters);
+  converters = (options.converters || []).concat(converters);
 
   var doc = htmlToDom(input);
   var clone = doc.body;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,11 +1,5 @@
-exports.isRegExp = function (obj) {
-  return Object.prototype.toString.call(obj) === '[object RegExp]';
-};
+'use strict';
 
 exports.trim = function (string) {
   return string.replace(/^\s+|\s+$/g, '');
 };
-
-exports.isArray = function (obj) {
-  return Array.isArray(obj);
-}

--- a/test/to-markdown-test.js
+++ b/test/to-markdown-test.js
@@ -355,31 +355,34 @@ test('leading/trailing whitespace', function() {
   equal(toMarkdown(lisWithTrailingWhitespaceHtml), lisWithTrailingWhitespaceMd, 'We expect list items with trailing whitespace to be converted');
 });
 
-test('custom converters/sub, sup', function() {
-  var converters = [{
-    filter: 'sub',
-    replacement: function(innerHTML) {
-      return '~' + innerHTML + '~';
-    }
-  }];
-  var html = 'This is normal text<sub>subscript</sub>';
-  var md = 'This is normal text~subscript~';
-  equal(toMarkdown(html, {converters: converters}), md, 'We expect sub to be converted');
+test('custom converters', function() {
+  var html, converter, md = '*Hello world*';
+  var replacement = function (innerHTML) {
+    return '*' + innerHTML + '*';
+  };
 
-  converters = [{
-    filter: 'sub',
-    replacement: function(innerHTML) {
-      return '~' + innerHTML + '~';
-    }
-  }, {
-    filter: 'sup',
-    replacement: function(innerHTML) {
-      return '^' + innerHTML + '^';
-    }
-  }];
-  html = 'This is normal text<sub>subscript</sub>. Another normal text<sup>superscript</sup>';
-  md = 'This is normal text~subscript~. Another normal text^superscript^';
-  equal(toMarkdown(html, {converters: converters}), md, 'We expect sup to be converted');
+  html = '<span>Hello world</span>';
+  converter = {
+    filter: 'span',
+    replacement: replacement
+  };
+  equal(toMarkdown(html, {converters: [converter]}), md, 'Custom filter string');
+
+  html = '<span>Hello world</span>';
+  converter = {
+    filter: ['span'],
+    replacement: replacement
+  };
+  equal(toMarkdown(html, {converters: [converter]}), md, 'Custom filter array');
+
+  html = '<span style="font-style: italic">Hello world</span>';
+  converter = {
+    filter: function (node) {
+      return node.tagName === 'SPAN' && /italic/i.test(node.style.fontStyle);
+    },
+    replacement: replacement
+  };
+  equal(toMarkdown(html, {converters: [converter]}), md, 'Custom filter function');
 });
 
 asyncTest('img[onerror]', 1, function () {


### PR DESCRIPTION
This PR removes some unnecessary utilities, documents the custom converter API, and uses spans for testing custom converters (sup/sub maybe converted in the future).

If you merge this in, hopefully it’ll appear in https://github.com/domchristie/to-markdown/pull/69

Thanks!
